### PR TITLE
帮助文档-增加Zsh命令行scheme参数注意事项

### DIFF
--- a/docs/concepts/proxy.md
+++ b/docs/concepts/proxy.md
@@ -28,14 +28,15 @@
     服务端
 	```
 	gost -L relay+wss://gost:gost@:8420
+	# 或者：gost -L relay+wss://gost:gost@192.168.1.1:8420
 	```
 
 	客户端
 	```
-	gost -L http://:8080 -F relay+wss://gost:gost@:8420
+	gost -L http://:8080 -F relay+wss://gost:gost@192.168.1.1:8420
 	```
 
-	客户端使用TCP数据通道通过HTTP代理协议接收请求，使用Websocket数据通道通过relay协议转发给服务端处理，并开启认证。这里数据在两层代理(HTTP代理和Relay代理)之间进行传输。
+	客户端使用TCP数据通道通过HTTP代理协议接收请求，使用Websocket数据通道通过relay协议转发给服务端192.168.1.1处理，并开启认证。这里数据在两层代理(HTTP代理和Relay代理)之间进行传输。
 
 === "Relay转发模式"
 

--- a/docs/reference/configuration/cmd.md
+++ b/docs/reference/configuration/cmd.md
@@ -126,3 +126,17 @@ scheme://[bind_address]:port/[host]:hostport[?key1=value1&key2=value2]
     ```
 	gost -L http://:8080 -metrics :9000
 	```
+
+
+!!! tip "scheme参数在命令行中的问题"
+    macOS系统默认的zsh不支持命令行参数使用`?`和`&`，所以在macOS环境下，如果你的scheme包含特殊字符，请使用双引号`""`，否则会报错：“zsh: no matches found: ...”。
+
+=== "Bash"
+    ```
+	gost -L http://:8080 -L socks5://:1080?foo=bar
+	```
+
+=== "Zsh"
+    ```
+	gost -L http://:8080 -L "socks5://:1080?foo=bar"
+	```

--- a/en/docs/reference/configuration/cmd.md
+++ b/en/docs/reference/configuration/cmd.md
@@ -126,3 +126,16 @@ scheme://[bind_address]:port/[host]:hostport[?key1=value1&key2=value2]
     ```
 	gost -L http://:8080 -metrics :9000
 	```
+
+!!! tip "Handle special characters in command line scheme"
+    Zsh in macOS does not support `?` and `&`, you have to use `""` to quote them,otherwise you'll get warnings in Terminal: "zsh: no matches found: ..."。
+
+=== "Bash"
+    ```
+	gost -L http://:8080 -L socks5://:1080?foo=bar
+	```
+
+=== "Zsh"
+    ```
+	gost -L http://:8080 -L "socks5://:1080?foo=bar"
+	```


### PR DESCRIPTION
zsh命令行默认不支持`?`和`&`，需要通过双引号`""`处理一下。